### PR TITLE
sort can also uniq

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@
 
 ## Haltestellen
 
-    osmfilter Dortmund.osm --keep="public_transport=stop_position or =station or =platform or =stop_area" --ignore-dependencies --drop-relations | osmconvert --csv="name" - | sort | uniq | jq -R '[.]' | jq -s -c 'add' | sed -e "s/^/{ \"words\" :/" -e "s/\$/}/" > dsw21.json
+    osmfilter Dortmund.osm --keep="public_transport=stop_position or =station or =platform or =stop_area" --ignore-dependencies --drop-relations | osmconvert --csv="name" - | sort -u | jq -R '[.]' | jq -s -c 'add' | sed -e "s/^/{ \"words\" :/" -e "s/\$/}/" > dsw21.json
 
 ## Straßen
 
-    osmfilter Dortmund.osm --keep="highway and name" --drop="highway=bus_stop or =motorway_junction =elevator or =traffic_signals or =crossing or =street_lamp or =emergency_access_point or public_transport" --ignore-dependencies --drop-relations | osmconvert --csv="name" - | sort | uniq | jq -R '[.]' | jq -s -c 'add' | sed -e "s/^/{ \"words\" :/" -e "s/\$/}/" > strassen.json
+    osmfilter Dortmund.osm --keep="highway and name" --drop="highway=bus_stop or =motorway_junction =elevator or =traffic_signals or =crossing or =street_lamp or =emergency_access_point or public_transport" --ignore-dependencies --drop-relations | osmconvert --csv="name" - | sort -u | jq -R '[.]' | jq -s -c 'add' | sed -e "s/^/{ \"words\" :/" -e "s/\$/}/" > strassen.json
 
 ## POI
 
-    osmfilter Dortmund.osm --keep="tourism or leisure or amenity" --ignore-dependencies --drop-relations | osmconvert --csv="name" - | sort | uniq | jq -R '[.]' | jq -s -c 'add' | sed -e "s/^/{ \"words\" :/" -e "s/\$/}/" > poi.json
+    osmfilter Dortmund.osm --keep="tourism or leisure or amenity" --ignore-dependencies --drop-relations | osmconvert --csv="name" - | sort -u | jq -R '[.]' | jq -s -c 'add' | sed -e "s/^/{ \"words\" :/" -e "s/\$/}/" > poi.json
 
 # Credits
 


### PR DESCRIPTION
`sort | uniq` ist äquivalent mit `sort -u`.
Wobei `sort -u` nur ein Prozessaufruf ist und eine Inter-Prozess-Kommunikation einspart.
